### PR TITLE
[websocket] 웹소켓 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // Security
+    // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // jwt
@@ -44,6 +44,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/inssurify/common/config/WebSocketConfig.java
+++ b/src/main/java/com/example/inssurify/common/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.example.inssurify.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/send");       //클라이언트에서 보낸 메세지를 받을 prefix
+        registry.enableSimpleBroker("/room");    //해당 주소를 구독하고 있는 클라이언트들에게 메세지 전달
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-stomp")   //SockJS 연결 주소
+                .withSockJS(); //버전 낮은 브라우저에서도 적용 가능
+        // 주소 : ws://localhost:8080/ws-stomp
+    }
+}

--- a/src/main/java/com/example/inssurify/domain/stomp/MeetingRoom.java
+++ b/src/main/java/com/example/inssurify/domain/stomp/MeetingRoom.java
@@ -1,0 +1,19 @@
+package com.example.inssurify.domain.stomp;
+
+import com.example.inssurify.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+}

--- a/src/main/java/com/example/inssurify/domain/stomp/actions/Check.java
+++ b/src/main/java/com/example/inssurify/domain/stomp/actions/Check.java
@@ -1,0 +1,23 @@
+package com.example.inssurify.domain.stomp.actions;
+
+import com.example.inssurify.domain.common.BaseEntity;
+import com.example.inssurify.domain.stomp.MeetingRoom;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "`check`") // SQL 예약어와의 충돌 방지
+public class Check extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "room_id")
+    private MeetingRoom room;
+}

--- a/src/main/java/com/example/inssurify/domain/stomp/actions/GoNext.java
+++ b/src/main/java/com/example/inssurify/domain/stomp/actions/GoNext.java
@@ -1,0 +1,22 @@
+package com.example.inssurify.domain.stomp.actions;
+
+import com.example.inssurify.domain.common.BaseEntity;
+import com.example.inssurify.domain.stomp.MeetingRoom;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoNext extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "room_id")
+    private MeetingRoom room;
+}

--- a/src/main/java/com/example/inssurify/domain/stomp/actions/Sign.java
+++ b/src/main/java/com/example/inssurify/domain/stomp/actions/Sign.java
@@ -1,0 +1,22 @@
+package com.example.inssurify.domain.stomp.actions;
+
+import com.example.inssurify.domain.common.BaseEntity;
+import com.example.inssurify.domain.stomp.MeetingRoom;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sign extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "room_id")
+    private MeetingRoom room;
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #12 

## 💻 작업 내용
- [x] WebSocketConfig 설정
- [x] WebSocket 통신 관련 Entity 생성

## ✅ PR Point
1. WebSocketConfig 설정
```java
@Configuration
@RequiredArgsConstructor
@EnableWebSocketMessageBroker
public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {

    @Override
    public void configureMessageBroker(MessageBrokerRegistry registry) {
        registry.setApplicationDestinationPrefixes("/send");       //클라이언트에서 보낸 메세지를 받을 prefix
        registry.enableSimpleBroker("/room");    //해당 주소를 구독하고 있는 클라이언트들에게 메세지 전달
    }

    @Override
    public void registerStompEndpoints(StompEndpointRegistry registry) {
        registry.addEndpoint("/ws-stomp")   //SockJS 연결 주소
                .withSockJS(); //버전 낮은 브라우저에서도 적용 가능
        // 주소 : ws://localhost:8080/ws-stomp
    }
}
```

2. WebSocket 통신 관련 Entity 생성 : 회의실, 액션(체크, 서명, 다음)
<img width="904" alt="스크린샷 2024-11-12 오전 7 02 00" src="https://github.com/user-attachments/assets/4e7f8811-dbfd-4aa6-8a4f-2528a2f1a74d">
