### PR TITLE
[WebRTC] WebRTC 시그널링 서버 구축 #24

### DIFF
--- a/src/main/java/com/example/ensurify/WebRTC/SessionRepository.java
+++ b/src/main/java/com/example/ensurify/WebRTC/SessionRepository.java
@@ -1,0 +1,99 @@
+package com.example.ensurify.WebRTC;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+// 기능 : 웹소켓에 필요한 세션 정보를 저장, 관리 (싱글톤)
+@Slf4j
+@Component
+@NoArgsConstructor
+public class SessionRepository {
+    private static SessionRepository sessionRepositoryRepo;
+    // 세션 저장 1) clientsInRoom : 방 Id를 key 값으로 하여 방마다 가지고 있는 Client들의 session Id 와 session 객체를 저장
+    private final Map<Long, Map<String, WebSocketSession>> clientsInRoom = new HashMap<>();
+    // 세션 저장 2) roomIdToSession : 참가자들 각각의 데이터로 session 객체를 key 값으로 하여 해당 객체가 어느방에 속해있는지를 저장
+    private final Map<WebSocketSession, Long> roomIdToSession = new HashMap<>();
+
+    // Session 데이터를 공통으로 사용하기 위해 싱글톤으로 구현
+    public static SessionRepository getInstance(){
+        if(sessionRepositoryRepo == null){
+            synchronized (SessionRepository.class){
+                sessionRepositoryRepo = new SessionRepository();
+            }
+        }
+        return sessionRepositoryRepo;
+    }
+
+    // 해당 방의 ClientList 조회
+    public Map<String, WebSocketSession> getClientList(Long roomId) {
+        return clientsInRoom.get(roomId);
+    }
+
+    // 해당 방 존재 유무 조회
+    public boolean hasRoom(Long roomId){
+        return clientsInRoom.containsKey(roomId);
+    }
+
+    // 해당 session이 어느방에 있는지 조회
+    public Long getRoomId(WebSocketSession session){
+        return roomIdToSession.get(session);
+    }
+
+    // 세션을 저장 및 수정해서 저장
+    public void addClientInNewRoom(Long roomId, WebSocketSession session) {
+        Map<String, WebSocketSession> newClient = new HashMap<>();
+        newClient.put(session.getId(), session);
+        clientsInRoom.put(roomId, newClient);
+    }
+
+    // 끊어진 Client session 하나만 지우고 다시 저장
+    public void deleteClient(Long roomId, WebSocketSession session) {
+        Map<String, WebSocketSession> clientList = clientsInRoom.get(roomId);
+        String removeKey = "";
+        for(Map.Entry<String, WebSocketSession> oneClient : clientList.entrySet()){
+            if(oneClient.getKey().equals(session.getId())){
+                removeKey = oneClient.getKey();
+            }
+        }
+        log.info("========== 지워질 session id : " + removeKey);
+        clientList.remove(removeKey);
+
+        // 끊어진 세션을 제외한 나머지 세션들을 다시 저장
+        clientsInRoom.put(roomId, clientList);
+    }
+
+    // 하나의 Client session 정보만 추가하기
+    public void addClient(Long roomId, WebSocketSession session) {
+        clientsInRoom.get(roomId).put(session.getId(), session);
+    }
+
+    // 방정보 모두 삭제 (방 폭파시 연계 작동)
+    public void deleteAllclientsInRoom(Long roomId){
+        clientsInRoom.remove(roomId);
+    }
+
+    public Map<WebSocketSession, Long> searchRoomIdToSession(Long roomId) {
+        return Optional.of(roomIdToSession.entrySet()
+                        .stream()
+                        .filter(entry ->  entry.getValue() == roomId)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .orElseThrow(
+                        () -> new IllegalArgumentException("RoodIdToSession 정보 없음!")
+                );
+    }
+
+    public void saveRoomIdToSession(WebSocketSession session, Long roomId) {
+        roomIdToSession.put(session, roomId);
+    }
+
+    public void deleteRoomIdToSession(WebSocketSession session) {
+        roomIdToSession.remove(session);
+    }
+}

--- a/src/main/java/com/example/ensurify/WebRTC/SignalConfig.java
+++ b/src/main/java/com/example/ensurify/WebRTC/SignalConfig.java
@@ -1,0 +1,25 @@
+package com.example.ensurify.WebRTC;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class SignalConfig implements WebSocketConfigurer {
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(signalHandler(), "/signal")
+                .setAllowedOriginPatterns("*");
+//                .withSockJS(); // allow all origins
+    }
+
+    @Bean
+    public WebSocketHandler signalHandler() {
+        return new SignalHandler();
+    }
+}

--- a/src/main/java/com/example/ensurify/WebRTC/SignalHandler.java
+++ b/src/main/java/com/example/ensurify/WebRTC/SignalHandler.java
@@ -1,0 +1,194 @@
+package com.example.ensurify.WebRTC;
+
+import com.example.ensurify.dto.response.StompResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+import java.io.IOException;
+import java.util.*;
+
+// 기능 : WebRTC를 위한 시그널링 서버 부분으로 요청타입에 따라 분기 처리
+@Slf4j
+public class SignalHandler extends TextWebSocketHandler {
+
+    private final SessionRepository sessionRepositoryRepo = SessionRepository.getInstance();  // 세션 데이터 저장소
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String MSG_TYPE_JOIN_ROOM = "join_room";
+    private static final String MSG_TYPE_OFFER = "offer";
+    private static final String MSG_TYPE_ANSWER = "answer";
+    private static final String MSG_TYPE_CANDIDATE = "candidate";
+
+    // 웹소켓이 연결되면 실행되는 메소드
+    @Override
+    public void afterConnectionEstablished(final WebSocketSession session) {
+        log.info("connection established, session id={}", session.getId());
+
+        // 세션 ID 생성 후, 클라이언트에 전송
+        String sessionId = session.getId();
+
+        StompResponse response = StompResponse.builder()
+                .sessionId(sessionId)
+                .build();
+
+        try {
+            String jsonResponse = objectMapper.writeValueAsString(response);
+            session.sendMessage(new TextMessage(jsonResponse));
+            log.info("Session connected: {}", session.getId());
+
+        } catch (IOException e) {
+            log.error("Error sending session ID: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    protected void handleTextMessage(final WebSocketSession session, final TextMessage textMessage) {
+
+        try {
+            WebSocketMessage message = objectMapper.readValue(textMessage.getPayload(), WebSocketMessage.class);
+            String userName = message.getSender();
+            String data = message.getData();
+            Long roomId = message.getRoomId();
+
+            log.info("======================================== origin message INFO");
+            log.info("==========session.Id : {}, getType : {},  getRoomId :  {}", session.getId(), message.getType(), roomId.toString());
+
+
+            switch (message.getType()) {
+                // 처음 입장
+                case MSG_TYPE_JOIN_ROOM:
+
+                    if (sessionRepositoryRepo.hasRoom(roomId)) {
+                        log.info("==========join 0 : 방 있음 :" + roomId);
+                        log.info("==========join 1 : (join 전) Client List - \n {} \n", Optional.ofNullable(sessionRepositoryRepo.getClientList(roomId)));
+
+                        // 해당 챗룸이 존재하면
+                        // 세션 저장 1) : 게임방 안의 session List에 새로운 Client session정보를 저장
+                        sessionRepositoryRepo.addClient(roomId, session);
+
+                    } else {
+                        log.info("==========join 0 : 방 없음 :" + roomId);
+                        // 해당 챗룸이 존재하지 않으면
+                        // 세션 저장 1) : 새로운 게임방 정보와 새로운 Client session정보를 저장
+                        sessionRepositoryRepo.addClientInNewRoom(roomId, session);
+                    }
+
+                    log.info("==========join 2 : (join 후) Client List - \n {} \n", Optional.ofNullable(sessionRepositoryRepo.getClientList(roomId)));
+
+                    // 세션 저장 2) : 이 세션이 어느 방에 들어가 있는지 저장
+                    sessionRepositoryRepo.saveRoomIdToSession(session, roomId);
+
+                    log.info("==========join 3 : 지금 세션이 들어간 방 :" + Optional.ofNullable(sessionRepositoryRepo.getRoomId(session)));
+
+                    // 방안 참가자 중 자신을 제외한 나머지 사람들의 Session ID를 List로 저장
+                    List<String> exportClientList = new ArrayList<>();
+                    for (Map.Entry<String, WebSocketSession> entry : sessionRepositoryRepo.getClientList(roomId).entrySet()) {
+                        if (entry.getValue() != session) {
+                            exportClientList.add(entry.getKey());
+                        }
+                    }
+
+                    log.info("==========join 4 : allUsers로 Client List : {}", exportClientList);
+
+                    // 접속한 본인에게 방안 참가자들 정보를 전송
+                    sendMessage(session,
+                            new WebSocketMessage().builder()
+                                    .type("all_users")
+                                    .sender(userName)
+                                    .data(message.getData())
+                                    .allUsers(exportClientList)
+                                    .candidate(message.getCandidate())
+                                    .sdp(message.getSdp())
+                                    .build());
+
+                    break;
+
+                case MSG_TYPE_OFFER:
+                case MSG_TYPE_ANSWER:
+                case MSG_TYPE_CANDIDATE:
+
+                    if (sessionRepositoryRepo.hasRoom(roomId)) {
+                        Map<String, WebSocketSession> clientList = sessionRepositoryRepo.getClientList(roomId);
+
+                        log.info("=========={} 5 : 보내는 사람 - {}, 받는 사람 - {}" + message.getType(), session.getId(), message.getReceiver());
+
+                        if (clientList.containsKey(message.getReceiver())) {
+                            WebSocketSession ws = clientList.get(message.getReceiver());
+                            sendMessage(ws,
+                                    new WebSocketMessage().builder()
+                                            .type(message.getType())
+                                            .sender(session.getId())            // 보낸사람 session Id
+                                            .receiver(message.getReceiver())    // 받을사람 session Id
+                                            .data(message.getData())
+                                            .offer(message.getOffer())
+                                            .answer(message.getAnswer())
+                                            .candidate(message.getCandidate())
+                                            .sdp(message.getSdp())
+                                            .build());
+                        }
+                    }
+                    break;
+
+                default:
+                    log.info("======================================== DEFAULT");
+                    log.info("============== 들어온 타입 : " + message.getType());
+
+            }
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(final WebSocketSession session, final CloseStatus status) {
+        // 웹소켓 연결이 끊어지면 실행되는 메소드
+        log.info("======================================== 웹소켓 연결 해제 : {}", session.getId());
+        // 끊어진 세션이 어느방에 있었는지 조회
+        Long roomId = Optional.ofNullable(sessionRepositoryRepo.getRoomId(session)).orElseThrow(
+                () -> new IllegalArgumentException("해당 세션이 있는 방정보가 없음!")
+        );
+
+        // 1) 방 참가자들 세션 정보들 사이에서 삭제
+        log.info("==========leave 1 : (삭제 전) Client List - \n {} \n", Optional.ofNullable(sessionRepositoryRepo.getClientList(roomId)));
+        sessionRepositoryRepo.deleteClient(roomId, session);
+        log.info("==========leave 2 : (삭제 후) Client List - \n {} \n", Optional.ofNullable(sessionRepositoryRepo.getClientList(roomId)));
+
+
+        // 2) 별도 해당 참가자 세션 정보도 삭제
+        log.info("==========leave 3 : (삭제 전) roomId to Session - \n {} \n", Optional.ofNullable(sessionRepositoryRepo.searchRoomIdToSession(roomId)));
+        sessionRepositoryRepo.deleteRoomIdToSession(session);
+        log.info("==========leave 4 : (삭제 후) roomId to Session - \n {} \n", Optional.ofNullable(sessionRepositoryRepo.searchRoomIdToSession(roomId)));
+
+
+        // 본인 제외 모두에게 전달
+        Map<String, WebSocketSession> clientList = Optional.ofNullable(sessionRepositoryRepo.getClientList(roomId))
+                .orElseThrow(
+                        () -> new IllegalArgumentException("clientList 없음")
+                );
+        for(Map.Entry<String, WebSocketSession> oneClient : clientList.entrySet()){
+            sendMessage(oneClient.getValue(),
+                    new WebSocketMessage().builder()
+                            .type("leave")
+                            .sender(session.getId())
+                            .receiver(oneClient.getKey())
+                            .build());
+        }
+
+    }
+
+    // 메세지 발송
+    private void sendMessage(WebSocketSession session, WebSocketMessage message) {
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            log.info("========== 발송 to : " + session.getId());
+            log.info("========== 발송 내용 : " + json);
+            session.sendMessage(new TextMessage(json));
+        } catch (IOException e) {
+            log.info("============== 발생한 에러 메세지: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/ensurify/WebRTC/SignalHandler.java
+++ b/src/main/java/com/example/ensurify/WebRTC/SignalHandler.java
@@ -4,7 +4,6 @@ import com.example.ensurify.dto.response.StompResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -26,8 +25,6 @@ public class SignalHandler extends TextWebSocketHandler {
     // 웹소켓이 연결되면 실행되는 메소드
     @Override
     public void afterConnectionEstablished(final WebSocketSession session) {
-        log.info("connection established, session id={}", session.getId());
-
         // 세션 ID 생성 후, 클라이언트에 전송
         String sessionId = session.getId();
 
@@ -38,7 +35,7 @@ public class SignalHandler extends TextWebSocketHandler {
         try {
             String jsonResponse = objectMapper.writeValueAsString(response);
             session.sendMessage(new TextMessage(jsonResponse));
-            log.info("Session connected: {}", session.getId());
+            log.info("connection established, session id={}", session.getId());
 
         } catch (IOException e) {
             log.error("Error sending session ID: {}", e.getMessage());
@@ -51,7 +48,6 @@ public class SignalHandler extends TextWebSocketHandler {
         try {
             WebSocketMessage message = objectMapper.readValue(textMessage.getPayload(), WebSocketMessage.class);
             String userName = message.getSender();
-            String data = message.getData();
             Long roomId = message.getRoomId();
 
             log.info("======================================== origin message INFO");

--- a/src/main/java/com/example/ensurify/WebRTC/WebSocketMessage.java
+++ b/src/main/java/com/example/ensurify/WebRTC/WebSocketMessage.java
@@ -30,17 +30,40 @@ public class WebSocketMessage {
     public void setFrom(String from) {
         this.sender = from;
     }
+
     public void setType(String type) {
         this.type = type;
     }
-    public void setOffer(Objects offer) {
+
+    public void setOffer(Object offer) {
         this.offer = offer;
     }
+
+    public void setAnswer(Object answer) {
+        this.answer = answer;
+    }
+
     public void setCandidate(Object candidate) {
         this.candidate = candidate;
     }
 
     public void setSdp(Object sdp) {
         this.sdp = sdp;
+    }
+
+    public void setRoomId(Long roomId) {
+        this.roomId = roomId;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public void setAllUsers(List<String> allUsers) {
+        this.allUsers = allUsers;
+    }
+
+    public void setReceiver(String receiver) {
+        this.receiver = receiver;
     }
 }

--- a/src/main/java/com/example/ensurify/WebRTC/WebSocketMessage.java
+++ b/src/main/java/com/example/ensurify/WebRTC/WebSocketMessage.java
@@ -1,0 +1,46 @@
+package com.example.ensurify.WebRTC;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+
+// 기능 : 프론트에 응답하는 시그널링용 Message
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebSocketMessage {
+    private String sender;
+    private String type; // join_room, offer, answer, candidate
+    private Long roomId;
+    private String data;
+    private List<String> allUsers;
+    private String receiver;
+    private Object offer;
+    private Object answer;
+    private Object candidate;
+    private Object sdp;
+
+    public void setFrom(String from) {
+        this.sender = from;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+    public void setOffer(Objects offer) {
+        this.offer = offer;
+    }
+    public void setCandidate(Object candidate) {
+        this.candidate = candidate;
+    }
+
+    public void setSdp(Object sdp) {
+        this.sdp = sdp;
+    }
+}

--- a/src/main/java/com/example/ensurify/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/ensurify/common/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/users/login", "/contracts/docs/**", "/clients/**", "/health")
                         .permitAll()
-                        .requestMatchers("/ws-stomp")
+                        .requestMatchers("/ws-stomp", "/signal")
                         .permitAll()
                         .anyRequest().authenticated())
 

--- a/src/main/java/com/example/ensurify/common/config/WebSocketConfig.java
+++ b/src/main/java/com/example/ensurify/common/config/WebSocketConfig.java
@@ -1,15 +1,18 @@
 package com.example.ensurify.common.config;
 
+import com.example.ensurify.WebRTC.SignalHandler;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.*;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSocketMessageBroker
+@Slf4j
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
@@ -20,9 +23,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-stomp")   //SockJS 연결 주소
+        registry.addEndpoint("/ws-stomp")   //SockJS 연결 주소(ws://localhost:8080/ws-stomp)
                 .setAllowedOriginPatterns("*"); //CORS 허용 설정
 //                .withSockJS(); //버전 낮은 브라우저에서도 적용 가능
-        // 주소(클라이언트 사용) : ws://localhost:8080/ws-stomp
     }
 }

--- a/src/main/java/com/example/ensurify/controller/WebSocketController.java
+++ b/src/main/java/com/example/ensurify/controller/WebSocketController.java
@@ -5,15 +5,11 @@ import com.example.ensurify.dto.request.CheckRequest;
 import com.example.ensurify.dto.request.MovePageRequest;
 import com.example.ensurify.dto.request.SignRequest;
 import com.example.ensurify.service.WebSocketService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.*;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -24,16 +20,14 @@ import static com.example.ensurify.common.jwt.TokenAuthenticationFilter.getAcces
 @Slf4j
 @Controller
 @RequiredArgsConstructor
-@Tag(name = "WebSocket", description = "WebSocket 관련 API입니다.")
 public class WebSocketController {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final WebSocketService webSocketService;
     private final TokenProvider tokenProvider;
 
-    // 체크 내역 수신
+    // 체크 내역 송수신
     @MessageMapping("/check")
-    @Operation(summary = "체크", description = "체크 내역을 송수신합니다.")
     public void check(@Payload @Valid CheckRequest request, @Header(HEADER_AUTHORIZATION) String authorizationHeader) {
 
         String accessToken = getAccessToken(authorizationHeader);
@@ -49,9 +43,8 @@ public class WebSocketController {
     }
 
 
-    // 서명 수신
+    // 서명 송수신
     @MessageMapping("/sign")
-    @Operation(summary = "서명", description = "서명 이미지를 송수신합니다.")
     public void sign(@Payload @Valid SignRequest request, @Header(HEADER_AUTHORIZATION) String authorizationHeader) {
 
         String accessToken = getAccessToken(authorizationHeader);
@@ -66,9 +59,8 @@ public class WebSocketController {
         log.info("meetingRoom={}, signNum={}, imgUrl={}", request.getMeetingRoomId(), request.getSignNum(), request.getImgUrl());
     }
 
-    // 페이지 번호 수신
+    // 페이지 번호 송수신(이동용)
     @MessageMapping("/page")
-    @Operation(summary = "페이지 이동", description = "페이지 번호를 통해 이동합니다.")
     public void movePage(@Payload @Valid MovePageRequest request, @Header(HEADER_AUTHORIZATION) String authorizationHeader) {
 
         String accessToken = getAccessToken(authorizationHeader);

--- a/src/main/java/com/example/ensurify/controller/WebSocketController.java
+++ b/src/main/java/com/example/ensurify/controller/WebSocketController.java
@@ -34,12 +34,12 @@ public class WebSocketController {
         Authentication authentication = tokenProvider.getAuthentication(accessToken);
         Long userId = Long.parseLong(authentication.getName());
 
-        webSocketService.validMeetingRoom(request.getMeetingRoomId(), userId);
+        webSocketService.validRoom(request.getRoomId(), userId);
         webSocketService.validCheck(request);
 
         // 메시지를 해당 회의실 구독자들에게 전송
-        messagingTemplate.convertAndSend("/sub/meetingroom/" + request.getMeetingRoomId(), request);
-        log.info("meetingRoom={}, checkNum={}, checked={}", request.getMeetingRoomId(), request.getCheckNum(), request.isChecked());
+        messagingTemplate.convertAndSend("/sub/rooms/" + request.getRoomId(), request);
+        log.info("room={}, checkNum={}, checked={}", request.getRoomId(), request.getCheckNum(), request.isChecked());
     }
 
 
@@ -51,12 +51,12 @@ public class WebSocketController {
         Authentication authentication = tokenProvider.getAuthentication(accessToken);
         Long userId = Long.parseLong(authentication.getName());
 
-        webSocketService.validMeetingRoom(request.getMeetingRoomId(), userId);
+        webSocketService.validRoom(request.getRoomId(), userId);
         webSocketService.validSign(request);
 
         // 메시지를 해당 회의실 구독자들에게 전송
-        messagingTemplate.convertAndSend("/sub/meetingroom/" + request.getMeetingRoomId(), request);
-        log.info("meetingRoom={}, signNum={}, imgUrl={}", request.getMeetingRoomId(), request.getSignNum(), request.getImgUrl());
+        messagingTemplate.convertAndSend("/sub/rooms/" + request.getRoomId(), request);
+        log.info("room={}, signNum={}, imgUrl={}", request.getRoomId(), request.getSignNum(), request.getImgUrl());
     }
 
     // 페이지 번호 송수신(이동용)
@@ -67,11 +67,11 @@ public class WebSocketController {
         Authentication authentication = tokenProvider.getAuthentication(accessToken);
         Long userId = Long.parseLong(authentication.getName());
 
-        webSocketService.validMeetingRoom(request.getMeetingRoomId(), userId);
+        webSocketService.validRoom(request.getRoomId(), userId);
         webSocketService.validPage(request);
 
         // 메시지를 해당 회의실 구독자들에게 전송
-        messagingTemplate.convertAndSend("/sub/meetingroom/" + request.getMeetingRoomId(), request);
-        log.info("meetingRoom={}, pageNum={}", request.getMeetingRoomId(), request.getPageNum());
+        messagingTemplate.convertAndSend("/sub/rooms/" + request.getRoomId(), request);
+        log.info("room={}, pageNum={}", request.getRoomId(), request.getPageNum());
     }
 }

--- a/src/main/java/com/example/ensurify/dto/request/CheckRequest.java
+++ b/src/main/java/com/example/ensurify/dto/request/CheckRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class CheckRequest {
 
-    private Long meetingRoomId;
+    private Long roomId;
     private int checkNum;
     private boolean checked;
 }

--- a/src/main/java/com/example/ensurify/dto/request/MovePageRequest.java
+++ b/src/main/java/com/example/ensurify/dto/request/MovePageRequest.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public class MovePageRequest {
 
-    private Long meetingRoomId;
+    private Long roomId;
     private int pageNum;
 }

--- a/src/main/java/com/example/ensurify/dto/request/SignRequest.java
+++ b/src/main/java/com/example/ensurify/dto/request/SignRequest.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public class SignRequest {
-    private Long meetingRoomId;
+    private Long roomId;
     private int signNum;
     private String imgUrl;
 }

--- a/src/main/java/com/example/ensurify/dto/response/StompResponse.java
+++ b/src/main/java/com/example/ensurify/dto/response/StompResponse.java
@@ -1,0 +1,11 @@
+package com.example.ensurify.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StompResponse {
+    private String sessionId;
+}

--- a/src/main/java/com/example/ensurify/service/WebSocketService.java
+++ b/src/main/java/com/example/ensurify/service/WebSocketService.java
@@ -25,7 +25,7 @@ public class WebSocketService {
      * 회의실 검증
      */
     @Transactional
-    public void validMeetingRoom(Long meetingRoomId, Long userId) {
+    public void validRoom(Long meetingRoomId, Long userId) {
 
         User user = userService.findById(userId);
 

--- a/src/main/java/com/example/ensurify/service/WebSocketService.java
+++ b/src/main/java/com/example/ensurify/service/WebSocketService.java
@@ -46,7 +46,7 @@ public class WebSocketService {
     @Transactional
     public void validCheck(CheckRequest request) {
 
-        MeetingRoom meetingRoom = meetingRoomService.findById(request.getMeetingRoomId());
+        MeetingRoom meetingRoom = meetingRoomService.findById(request.getRoomId());
 
         if(meetingRoom.getContractDocument().getCheckTotal() < request.getCheckNum())
             throw new GeneralException(ErrorStatus.CHECK_NUM_NOT_FOUND);
@@ -58,7 +58,7 @@ public class WebSocketService {
     @Transactional
     public void validSign(SignRequest request) {
 
-        MeetingRoom meetingRoom = meetingRoomService.findById(request.getMeetingRoomId());
+        MeetingRoom meetingRoom = meetingRoomService.findById(request.getRoomId());
 
         if(meetingRoom.getContractDocument().getSignTotal() < request.getSignNum())
             throw new GeneralException(ErrorStatus.SIGN_NUM_NOT_FOUND);
@@ -71,7 +71,7 @@ public class WebSocketService {
     @Transactional
     public void validPage(MovePageRequest request) {
 
-        MeetingRoom meetingRoom = meetingRoomService.findById(request.getMeetingRoomId());
+        MeetingRoom meetingRoom = meetingRoomService.findById(request.getRoomId());
 
         if(meetingRoom.getContractDocument().getPageTotal() < request.getPageNum())
             throw new GeneralException(ErrorStatus.CHECK_NUM_NOT_FOUND);


### PR DESCRIPTION
## 🔥 Related Issues
- close #24 

## 💻 작업 내용
- [x] WebRTC 시그널링 서버 구축(/signal)(/ws-stomp와 구분)
- [x] SignalConfig 생성
- [x] SignalHandler : WebRTC를 위한 시그널링 서버 부분으로 요청타입에 따라 분기 처리
- [x] SessionRepository : 웹소켓에 필요한 세션 정보를 저장, 관리 (싱글톤)
- [x] WebSocketMessage : 프론트에 응답하는 시그널링용 Message 
- [x]  회의실 명칭 간소화 : meetingRoom to room

## ✅ PR Point
1️⃣ SignalConfig
```java 
@Configuration
@EnableWebSocket
public class SignalConfig implements WebSocketConfigurer {

    @Override
    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
        registry.addHandler(signalHandler(), "/signal")
                .setAllowedOriginPatterns("*");
//                .withSockJS(); // allow all origins
    }

    @Bean
    public WebSocketHandler signalHandler() {
        return new SignalHandler();
    }
}
```

2️⃣ SignalHandler : WebRTC를 위한 시그널링 서버 부분으로 요청타입에 따라 분기 처리
```java
@Slf4j
public class SignalHandler extends TextWebSocketHandler {

    private final SessionRepository sessionRepositoryRepo = SessionRepository.getInstance();  // 세션 데이터 저장소
    private final ObjectMapper objectMapper = new ObjectMapper();
    private static final String MSG_TYPE_JOIN_ROOM = "join_room";
    private static final String MSG_TYPE_OFFER = "offer";
    private static final String MSG_TYPE_ANSWER = "answer";
    private static final String MSG_TYPE_CANDIDATE = "candidate";

    // 웹소켓이 연결되면 실행되는 메소드
    @Override
    public void afterConnectionEstablished(final WebSocketSession session) {
        // 세션 ID 생성 후, 클라이언트에 전송
        String sessionId = session.getId();

        StompResponse response = StompResponse.builder()
                .sessionId(sessionId)
                .build();
...
```

3️⃣ SessionRepository : 웹소켓에 필요한 세션 정보를 저장, 관리 (싱글톤)
```java 
@Slf4j
@Component
@NoArgsConstructor
public class SessionRepository {
    private static SessionRepository sessionRepositoryRepo;
    // 세션 저장 1) clientsInRoom : 방 Id를 key 값으로 하여 방마다 가지고 있는 Client들의 session Id 와 session 객체를 저장
    private final Map<Long, Map<String, WebSocketSession>> clientsInRoom = new HashMap<>();
    // 세션 저장 2) roomIdToSession : 참가자들 각각의 데이터로 session 객체를 key 값으로 하여 해당 객체가 어느방에 속해있는지를 저장
    private final Map<WebSocketSession, Long> roomIdToSession = new HashMap<>();

    // Session 데이터를 공통으로 사용하기 위해 싱글톤으로 구현
    public static SessionRepository getInstance(){
        if(sessionRepositoryRepo == null){
            synchronized (SessionRepository.class){
                sessionRepositoryRepo = new SessionRepository();
            }
        }
        return sessionRepositoryRepo;
    }
...
```

4️⃣ WebSocketMessage : 프론트에 응답하는 시그널링용 Message 
```java
@Builder
@Getter
@JsonInclude(JsonInclude.Include.NON_NULL)
@NoArgsConstructor
@AllArgsConstructor
public class WebSocketMessage {
    private String sender;
    private String type; // join_room, offer, answer, candidate
    private Long roomId;
    private String data;
    private List<String> allUsers;
    private String receiver;
    private Object offer;
    private Object answer;
    private Object candidate;
    private Object sdp;
...
```

## ☀️ 스크린샷 / GIF / 화면 녹화
<img width="1149" alt="스크린샷 2024-12-03 오후 1 53 42" src="https://github.com/user-attachments/assets/4d58e7fa-1255-4c64-941d-c1972bf868ce">
<img width="1148" alt="스크린샷 2024-12-03 오후 1 53 50" src="https://github.com/user-attachments/assets/0ae26189-54dc-4cbb-b5d1-5a3c9408512e">

## 📚 Reference
- https://littlezero48.tistory.com/260